### PR TITLE
Update to support v8.3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.3.1.{build}
+version: 1.3.2.{build}
 image: Visual Studio 2017
 
 platform:

--- a/src/Sci_Position.h
+++ b/src/Sci_Position.h
@@ -18,7 +18,7 @@ typedef ptrdiff_t Sci_Position;
 typedef size_t Sci_PositionU;
 
 // For Sci_CharacterRange  which is defined as long to be compatible with Win32 CHARRANGE
-typedef long Sci_PositionCR;
+typedef intptr_t Sci_PositionCR;
 
 #ifdef _WIN32
 	#define SCI_METHOD __stdcall

--- a/src/Version.h
+++ b/src/Version.h
@@ -16,8 +16,8 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-#define VERSION_NUM				1,3,1,1
-#define VERSION_LINEAR			1311
-#define VERSION_LINEAR_TEXT		TEXT("1311")
-#define VERSION_TEXT			TEXT("1.3.1.1") // This must match the tag pushed on the server minus the "v"
+#define VERSION_NUM				1,3,2,0
+#define VERSION_LINEAR			1320
+#define VERSION_LINEAR_TEXT		TEXT("1320")
+#define VERSION_TEXT			TEXT("1.3.2") // This must match the tag pushed on the server minus the "v"
 #define VERSION_STAGE			TEXT("") // "alpha", "beta", ""

--- a/src/Version.h
+++ b/src/Version.h
@@ -16,8 +16,8 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-#define VERSION_NUM				1,3,1,0
-#define VERSION_LINEAR			1310
-#define VERSION_LINEAR_TEXT		TEXT("1310")
-#define VERSION_TEXT			TEXT("1.3.1") // This must match the tag pushed on the server minus the "v"
+#define VERSION_NUM				1,3,1,1
+#define VERSION_LINEAR			1311
+#define VERSION_LINEAR_TEXT		TEXT("1311")
+#define VERSION_TEXT			TEXT("1.3.1.1") // This must match the tag pushed on the server minus the "v"
 #define VERSION_STAGE			TEXT("") // "alpha", "beta", ""


### PR DESCRIPTION
See https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11198 for more information.

In order to get this to build on my machine under VS 2019 I also had to add an `#include <string>` to Config.h, but I don't know enough to know whether that's actually necessary. The auto-build didn't need it.